### PR TITLE
add styles for scrollbars because windows is gross

### DIFF
--- a/App.js
+++ b/App.js
@@ -146,7 +146,10 @@ export default function App(props) {
       <ApolloProvider client={client}>
         <ImageBackground
           source={require("./assets/images/iss-master.jpg")}
-          style={[styles.container, { width: dimensions.width }]}
+          style={[
+            styles.container,
+            { width: dimensions.width, overflow: "hidden" },
+          ]}
           progressiveRenderingEnabled
           onLayout={onRotate}
         >

--- a/package-lock.json
+++ b/package-lock.json
@@ -19482,6 +19482,343 @@
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-native": "^0.63.2"
+      },
+      "dependencies": {
+        "@types/yargs": {
+          "version": "13.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
+          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "metro-react-native-babel-preset": {
+          "version": "0.58.0",
+          "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.58.0.tgz",
+          "integrity": "sha512-MRriNW+fF6jxABsgPphocUY6mIhmCm8idcrQZ58fT3Iti2vCdtkaK32TyCGUNUptzhUe2/cbE57j4aC+eaodAA==",
+          "requires": {
+            "@babel/plugin-proposal-class-properties": "^7.0.0",
+            "@babel/plugin-proposal-export-default-from": "^7.0.0",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+            "@babel/plugin-proposal-optional-chaining": "^7.0.0",
+            "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+            "@babel/plugin-syntax-export-default-from": "^7.0.0",
+            "@babel/plugin-syntax-flow": "^7.2.0",
+            "@babel/plugin-transform-arrow-functions": "^7.0.0",
+            "@babel/plugin-transform-block-scoping": "^7.0.0",
+            "@babel/plugin-transform-classes": "^7.0.0",
+            "@babel/plugin-transform-computed-properties": "^7.0.0",
+            "@babel/plugin-transform-destructuring": "^7.0.0",
+            "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+            "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+            "@babel/plugin-transform-for-of": "^7.0.0",
+            "@babel/plugin-transform-function-name": "^7.0.0",
+            "@babel/plugin-transform-literals": "^7.0.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+            "@babel/plugin-transform-object-assign": "^7.0.0",
+            "@babel/plugin-transform-parameters": "^7.0.0",
+            "@babel/plugin-transform-react-display-name": "^7.0.0",
+            "@babel/plugin-transform-react-jsx": "^7.0.0",
+            "@babel/plugin-transform-react-jsx-source": "^7.0.0",
+            "@babel/plugin-transform-regenerator": "^7.0.0",
+            "@babel/plugin-transform-runtime": "^7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+            "@babel/plugin-transform-spread": "^7.0.0",
+            "@babel/plugin-transform-sticky-regex": "^7.0.0",
+            "@babel/plugin-transform-template-literals": "^7.0.0",
+            "@babel/plugin-transform-typescript": "^7.5.0",
+            "@babel/plugin-transform-unicode-regex": "^7.0.0",
+            "@babel/template": "^7.0.0",
+            "react-refresh": "^0.4.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "pretty-format": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+          "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "ansi-regex": "^4.0.0",
+            "ansi-styles": "^3.2.0",
+            "react-is": "^16.8.4"
+          },
+          "dependencies": {
+            "@jest/types": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+              "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+              "requires": {
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^1.1.1",
+                "@types/yargs": "^13.0.0"
+              }
+            },
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+            }
+          }
+        },
+        "promise": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+          "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+          "requires": {
+            "asap": "~2.0.6"
+          }
+        },
+        "react-native": {
+          "version": "0.63.3",
+          "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.63.3.tgz",
+          "integrity": "sha512-71wq13uNo5W8QVQnFlnzZ3AD+XgUBYGhpsxysQFW/hJ8GAt/J5o+Bvhy81FXichp6IBDJDh/JgfHH2gNji8dFA==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@react-native-community/cli": "^4.10.0",
+            "@react-native-community/cli-platform-android": "^4.10.0",
+            "@react-native-community/cli-platform-ios": "^4.10.0",
+            "abort-controller": "^3.0.0",
+            "anser": "^1.4.9",
+            "base64-js": "^1.1.2",
+            "event-target-shim": "^5.0.1",
+            "fbjs": "^1.0.0",
+            "fbjs-scripts": "^1.1.0",
+            "hermes-engine": "~0.5.0",
+            "invariant": "^2.2.4",
+            "jsc-android": "^245459.0.0",
+            "metro-babel-register": "0.59.0",
+            "metro-react-native-babel-transformer": "0.59.0",
+            "metro-source-map": "0.59.0",
+            "nullthrows": "^1.1.1",
+            "pretty-format": "^24.9.0",
+            "promise": "^8.0.3",
+            "prop-types": "^15.7.2",
+            "react-devtools-core": "^4.6.0",
+            "react-refresh": "^0.4.0",
+            "regenerator-runtime": "^0.13.2",
+            "scheduler": "0.19.1",
+            "stacktrace-parser": "^0.1.3",
+            "use-subscription": "^1.0.0",
+            "whatwg-fetch": "^3.0.0"
+          },
+          "dependencies": {
+            "@react-native-community/cli": {
+              "version": "4.13.0",
+              "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-4.13.0.tgz",
+              "integrity": "sha512-R+1VehIQ6VTLf+e7YOwzJk0F9tstfeSC4xy7oT6GSgB3FnXbTJGHFUp4siyO68Ae/gzGqt8SiUO145teWkP+ZA==",
+              "requires": {
+                "@hapi/joi": "^15.0.3",
+                "@react-native-community/cli-debugger-ui": "^4.9.0",
+                "@react-native-community/cli-hermes": "^4.13.0",
+                "@react-native-community/cli-server-api": "^4.13.0",
+                "@react-native-community/cli-tools": "^4.13.0",
+                "@react-native-community/cli-types": "^4.10.1",
+                "chalk": "^3.0.0",
+                "command-exists": "^1.2.8",
+                "commander": "^2.19.0",
+                "cosmiconfig": "^5.1.0",
+                "deepmerge": "^3.2.0",
+                "envinfo": "^7.7.2",
+                "execa": "^1.0.0",
+                "find-up": "^4.1.0",
+                "fs-extra": "^8.1.0",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.1.3",
+                "inquirer": "^3.0.6",
+                "leven": "^3.1.0",
+                "lodash": "^4.17.15",
+                "metro": "^0.58.0",
+                "metro-config": "^0.58.0",
+                "metro-core": "^0.58.0",
+                "metro-react-native-babel-transformer": "^0.58.0",
+                "metro-resolver": "^0.58.0",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "node-stream-zip": "^1.9.1",
+                "ora": "^3.4.0",
+                "pretty-format": "^25.2.0",
+                "semver": "^6.3.0",
+                "serve-static": "^1.13.1",
+                "strip-ansi": "^5.2.0",
+                "sudo-prompt": "^9.0.0",
+                "wcwidth": "^1.0.1"
+              },
+              "dependencies": {
+                "metro-react-native-babel-transformer": {
+                  "version": "0.58.0",
+                  "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.58.0.tgz",
+                  "integrity": "sha512-3A73+cRq1eUPQ8g+hPNGgMUMCGmtQjwqHfoG1DwinAoJ/kr4WOXWWbGZo0xHJNBe/zdHGl0uHcDCp2knPglTdQ==",
+                  "requires": {
+                    "@babel/core": "^7.0.0",
+                    "babel-preset-fbjs": "^3.3.0",
+                    "metro-babel-transformer": "0.58.0",
+                    "metro-react-native-babel-preset": "0.58.0",
+                    "metro-source-map": "0.58.0"
+                  }
+                },
+                "metro-source-map": {
+                  "version": "0.58.0",
+                  "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.58.0.tgz",
+                  "integrity": "sha512-yvN1YPmejmgiiS7T1aKBiiUTHPw2Vcm3r2TZ+DY92z/9PR4alysIywrCs/fTHs8rbDcKM5VfPCKGLpkBrbKeOw==",
+                  "requires": {
+                    "@babel/traverse": "^7.0.0",
+                    "@babel/types": "^7.0.0",
+                    "invariant": "^2.2.4",
+                    "metro-symbolicate": "0.58.0",
+                    "ob1": "0.58.0",
+                    "source-map": "^0.5.6",
+                    "vlq": "^1.0.0"
+                  }
+                },
+                "pretty-format": {
+                  "version": "25.5.0",
+                  "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+                  "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+                  "requires": {
+                    "@jest/types": "^25.5.0",
+                    "ansi-regex": "^5.0.0",
+                    "ansi-styles": "^4.0.0",
+                    "react-is": "^16.12.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "react-native-gesture-handler": {

--- a/web/index.html
+++ b/web/index.html
@@ -1,91 +1,125 @@
 <!DOCTYPE html>
 <html lang="%LANG_ISO_CODE%">
-  <head>
-    <meta charset="utf-8" />
-    <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
-    <!-- 
+
+<head>
+  <meta charset="utf-8" />
+  <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+  <!-- 
       This viewport works for phones with notches.
       It's optimized for gestures by disabling global zoom.
      -->
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1.00001, viewport-fit=cover"
-    />
-    <title>%WEB_TITLE%</title>
-    <style>
-      /**
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1.00001, viewport-fit=cover" />
+  <title>%WEB_TITLE%</title>
+  <style>
+    /**
        * Extend the react-native-web reset:
        * https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/StyleSheet/initialRules.js
        */
-      html,
-      body,
-      #root {
-        width: 100%;
-        /* To smooth any scrolling behavior */
-        -webkit-overflow-scrolling: touch;
-        margin: 0px;
-        padding: 0px;
-        /* Allows content to fill the viewport and go beyond the bottom */
-        min-height: 100%;
-      }
-      #root {
-        flex-shrink: 0;
-        flex-basis: auto;
-        flex-grow: 1;
-        display: flex;
-        flex: 1;
-      }
+    html,
+    body,
+    #root {
+      width: 100%;
+      /* To smooth any scrolling behavior */
+      -webkit-overflow-scrolling: touch;
+      margin: 0px;
+      padding: 0px;
+      /* Allows content to fill the viewport and go beyond the bottom */
+      min-height: 100%;
+    }
 
-      html {
-        scroll-behavior: smooth;
-        /* Prevent text size change on orientation change https://gist.github.com/tfausak/2222823#file-ios-8-web-app-html-L138 */
-        -webkit-text-size-adjust: 100%;
-        height: 100%;
-      }
+    #root {
+      flex-shrink: 0;
+      flex-basis: auto;
+      flex-grow: 1;
+      display: flex;
+      flex: 1;
+    }
 
-      body {
-        display: flex;
-        /* Allows you to scroll below the viewport; default value is visible */
-        overflow-y: auto;
-        overscroll-behavior-y: none;
-        text-rendering: optimizeLegibility;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-        -ms-overflow-style: scrollbar;
-      }
-      /* Enable for apps that support dark-theme */
-      /*@media (prefers-color-scheme: dark) {
+    html {
+      scroll-behavior: smooth;
+      /* Prevent text size change on orientation change https://gist.github.com/tfausak/2222823#file-ios-8-web-app-html-L138 */
+      -webkit-text-size-adjust: 100%;
+      height: 100%;
+    }
+
+    body {
+      display: flex;
+      /* Allows you to scroll below the viewport; default value is visible */
+      overflow-y: auto;
+      overscroll-behavior-y: none;
+      text-rendering: optimizeLegibility;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      -ms-overflow-style: scrollbar;
+    }
+
+    /* Enable for apps that support dark-theme */
+    /*@media (prefers-color-scheme: dark) {
         body {
           background-color: black;
         }
       }*/
-      ::placeholder {
-        /* Chrome, Firefox, Opera, Safari 10.1+ */
-        color: #ffffffb7;
-        opacity: 1; /* Firefox */
-      }
+    ::placeholder {
+      /* Chrome, Firefox, Opera, Safari 10.1+ */
+      color: #ffffffb7;
+      opacity: 1;
+      /* Firefox */
+    }
 
-      :-ms-input-placeholder {
-        /* Internet Explorer 10-11 */
-        color: #ffffffb7;
-      }
+    :-ms-input-placeholder {
+      /* Internet Explorer 10-11 */
+      color: #ffffffb7;
+    }
 
-      ::-ms-input-placeholder {
-        /* Microsoft Edge */
-        color: #ffffffb7;
-      }
-    </style>
-  </head>
+    ::-ms-input-placeholder {
+      /* Microsoft Edge */
+      color: #ffffffb7;
+    }
 
-  <body>
-    <!-- 
+    /* 
+    ::-webkit-scrollbar {
+      display: none;
+    } */
+
+    ::-webkit-scrollbar {
+      width: .5em;
+    }
+
+    ::-webkit-scrollbar-track {
+      -webkit-box-shadow: transparent;
+      box-shadow: transparent;
+    }
+
+    ::-webkit-scrollbar-thumb {
+      background-color: #ffffffb7;
+      outline: transparent;
+      border-radius: 9999px;
+    }
+    html::-webkit-scrollbar {
+     display: none;
+    }
+
+    html::-webkit-scrollbar-track {
+     display: none;
+    }
+
+    html::-webkit-scrollbar-thumb {
+     display: none;
+    }
+    #bg-image{
+      overflow: hidden
+    }
+</style>
+</head>
+
+<body>
+  <!-- 
       A generic no script element with a reload button and a message.
       Feel free to customize this however you'd like.
     -->
-    <noscript>
-      <form
-        action=""
-        style="
+  <noscript>
+    <form action="" style="
           background-color: #fff;
           position: fixed;
           top: 0;
@@ -93,22 +127,17 @@
           right: 0;
           bottom: 0;
           z-index: 9999;
-        "
-      >
-        <div
-          style="
+        ">
+      <div style="
             font-size: 18px;
             font-family: Helvetica, sans-serif;
             line-height: 24px;
             margin: 10%;
             width: 80%;
-          "
-        >
-          <p>Oh no! It looks like JavaScript is not enabled in your browser.</p>
-          <p style="margin: 20px 0">
-            <button
-              type="submit"
-              style="
+          ">
+        <p>Oh no! It looks like JavaScript is not enabled in your browser.</p>
+        <p style="margin: 20px 0">
+          <button type="submit" style="
                 background-color: #4630eb;
                 border-radius: 100px;
                 border: none;
@@ -118,15 +147,15 @@
                 font-weight: bold;
                 line-height: 20px;
                 padding: 6px 16px;
-              "
-            >
-              Reload
-            </button>
-          </p>
-        </div>
-      </form>
-    </noscript>
-    <!-- The root element for your Expo app. -->
-    <div id="root"></div>
-  </body>
+              ">
+            Reload
+          </button>
+        </p>
+      </div>
+    </form>
+  </noscript>
+  <!-- The root element for your Expo app. -->
+  <div id="root"></div>
+</body>
+
 </html>


### PR DESCRIPTION
Just when you think, "I wonder if Windows ever fixed their ugly scroll bars for whatever browser you might use", you fire up the app and it looks bad with big, chunky, white scrolling rectangles everywhere. 

Luckily, since the last time I had to deal with this, various browsers have agreed on some implementations for styling these nightmares so we can replace them with our own elegant but still accessible option in CSS without having to resort to any padding hacks. 

Also, apparently also on windows (?...not confirmed) the app itself was doing some weird stuff with overflow on the top level divs so I added a quick `overflow: "hidden"` which hopefully doesn't break something else.