### PR TITLE
added forgot, resetConfirm, and reset screens with included logic

### DIFF
--- a/.expo-shared/README.md
+++ b/.expo-shared/README.md
@@ -1,0 +1,11 @@
+> Why do I have a folder named ".expo-shared" in my project?
+
+The ".expo-shared" folder is created when running commands that produce state that is intended to be shared with all developers on the project. For example, "npx expo-optimize".
+
+> What does the "assets.json" file contain?
+
+The "assets.json" file describes the assets that have been optimized through "expo-optimize" and do not need to be processed again.
+
+> Should I commit the ".expo-shared" folder?
+
+Yes, you should share the ".expo-shared" folder with your collaborators.

--- a/components/DisclaimerText.js
+++ b/components/DisclaimerText.js
@@ -8,7 +8,9 @@ export default function DisclaimerText({
   grey = false,
   spaced = false,
   blue = false,
+  noMargin = false,
   style = {},
+  text,
   ...props
 }) {
   const [activeTheme] = useGlobal("activeTheme");
@@ -21,12 +23,12 @@ export default function DisclaimerText({
     red ? { color: activeTheme.COLORS.RED } : {},
     green ? { color: activeTheme.COLORS.GREEN } : {},
     blue ? { color: activeTheme.COLORS.BLUE1 } : {},
-
+    noMargin ? styles.noMargin : {},
     style,
   ];
   return (
     <Text style={computedStyles} {...props}>
-      {props.text}
+      {props.children || text}
     </Text>
   );
 }
@@ -46,5 +48,8 @@ const styles = StyleSheet.create({
   },
   spaced: {
     letterSpacing: 2,
+  },
+  noMargin: {
+    marginBottom: 0,
   },
 });

--- a/components/Input.js
+++ b/components/Input.js
@@ -13,6 +13,7 @@ export default function Input({
   label = null,
   description = null,
   textStyle = {},
+  nextSibling = null,
   ...props
 }) {
   const inputEl = useRef();
@@ -50,6 +51,7 @@ export default function Input({
       {description && (
         <HelperText text={description} style={{ marginBottom: 0 }} />
       )}
+      {nextSibling || null}
     </TouchableOpacity>
   );
 }

--- a/graphql/mutations/index.js
+++ b/graphql/mutations/index.js
@@ -657,18 +657,26 @@ export const CREATE_USER = gql`
     }
   }
 `;
+// DEPRECATED - not in use since GraphCool
+// export const CREATE_RESET_REQUEST = gql`
+//   mutation($token: String!, $email: String!) {
+//     createResetRequest(token: $token, email: $email) {
+//       id
+//     }
+//   }
+// `;
 export const CREATE_RESET_REQUEST = gql`
-  mutation($token: String!, $email: String!) {
-    createResetRequest(token: $token, email: $email) {
-      id
+  mutation($email: String!) {
+    forgotPassword(email: $email) {
+      success
     }
   }
 `;
 
-export const UPDATE_USER_PASSWORD = gql`
-  mutation($user: ID!, $password: String!) {
-    updateUser(id: $user, password: $password) {
-      id
+export const UPDATE_PASSWORD = gql`
+  mutation($token: String!, $password: String!) {
+    resetPassword(token: $token, password: $password) {
+      success
     }
   }
 `;

--- a/graphql/queries/index.js
+++ b/graphql/queries/index.js
@@ -428,12 +428,12 @@ export const GET_DMS_BY_USER = gql`
 `;
 
 export const GET_RESET_REQUEST = gql`
-  query($id: ID!) {
-    ResetRequest(id: $id) {
-      id
-      token
-      email
-      createdAt
+  query($token: String!) {
+    resetRequestsList(last: 1, filter: { token: { equals: $token } }) {
+      items {
+        id
+        email
+      }
     }
   }
 `;

--- a/navigation/RootNavigation.js
+++ b/navigation/RootNavigation.js
@@ -15,3 +15,5 @@ export function getRoute() {
 export function goBack() {
   navigationRef.current.goBack();
 }
+
+window.navRef = navigationRef;

--- a/navigation/useLinking.js
+++ b/navigation/useLinking.js
@@ -2,13 +2,21 @@
 // import { Linking } from "expo";
 
 export const linkingConfig = {
-  prefixes: ["https://athar.es", "athares://", "http:localhost:19006"],
+  prefixes: ["https://athar.es", "athares://", "http://localhost:19006"],
   config: {
     screens: {
       // GOOD
       app: "",
       // GOOD
-      portal: "portal",
+      portal: {
+        screens: {
+          login: "login",
+          register: "register",
+          forgot: "forgot",
+          resetConfirm: "reset",
+          reset: "reset/:hashedCode",
+        },
+      },
       // GOOD
       createRevision: ":circle/revisions/create",
       // GOOD

--- a/screens/Channels/index.js
+++ b/screens/Channels/index.js
@@ -132,6 +132,17 @@ function Dashboard({ renderAsSidebar = false }) {
               <ChannelItem key={ch.id} showUnread={ch.unread} channel={ch} />
             ))}
           </Fragment>
+        ) : !activeCircle ? (
+          <View style={{ marginTop: 20 }}>
+            <CircleTitle title={"Welcome to Athares"} />
+            <DisclaimerText
+              grey
+              text={
+                "You have no circle selected, try creating a new one or search for an existing one."
+              }
+              style={{ marginHorizontal: 15 }}
+            />
+          </View>
         ) : (
           <View style={{ marginTop: 20 }}>
             <CircleTitle title={"Welcome to Athares"} />

--- a/screens/CircleSettings/index.js
+++ b/screens/CircleSettings/index.js
@@ -131,8 +131,6 @@ function CircleSettings(props) {
     return <CenteredErrorLoader text={"Error Getting Settings"} />;
   }
 
-  console.log(data, permissions);
-
   if (!permissions) {
     return (
       <CenteredErrorLoader text={"You Don't Have Access to this Circle"} />

--- a/screens/Portal/Forgot.js
+++ b/screens/Portal/Forgot.js
@@ -1,0 +1,96 @@
+import React, { useRef, useEffect, useState } from "reactn";
+import { View, StyleSheet } from "react-native";
+
+import MeshAlert from "../../utils/meshAlert";
+
+import * as RootNavigation from "../../navigation/RootNavigation";
+import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
+import { validateEmailAddress } from "../../utils/validators";
+
+import { CREATE_RESET_REQUEST } from "../../graphql/mutations";
+import { useMutation } from "@apollo/client";
+
+import Input from "../../components/Input";
+import GlowButton from "../../components/GlowButton";
+import DisclaimerText from "../../components/DisclaimerText";
+import CenteredLoaderWithText from "../../components/CenteredLoaderWithText";
+
+export default function Login() {
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const [createResetRequest] = useMutation(CREATE_RESET_REQUEST);
+
+  let _isMounted = useRef(false);
+
+  useEffect(() => {
+    _isMounted.current = true;
+
+    return () => {
+      _isMounted.current = false;
+    };
+  }, []);
+
+  const updateEmail = (text) => {
+    setEmail(text.toLowerCase());
+  };
+
+  const sendRequest = async () => {
+    setLoading(true);
+    const isValid = validateEmailAddress({ email });
+    if (isValid !== undefined) {
+      MeshAlert({
+        title: "Error",
+        text: isValid[Object.keys(isValid)[0]][0],
+        icon: "error",
+      });
+      setLoading(false);
+      return false;
+    }
+    try {
+      await createResetRequest({
+        variables: {
+          email,
+        },
+      });
+
+      _isMounted.current && setLoading(false);
+
+      RootNavigation.navigate("resetConfirm");
+    } catch (err) {
+      MeshAlert({
+        title: "Error",
+        text: "Unable to send reset request",
+        icon: "error",
+      });
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return <CenteredLoaderWithText text={"Sending Reset Request..."} />;
+  }
+
+  return (
+    <View style={styles.justifyBetween}>
+      <KeyboardAwareScrollView>
+        <DisclaimerText
+          text={`To reset your password, we need the email with which you created the account. Please enter it below.`}
+        />
+        <Input onChangeText={updateEmail} value={email} label={"Email"} />
+        <GlowButton text={"Request Password Reset"} onPress={sendRequest} />
+      </KeyboardAwareScrollView>
+      <DisclaimerText
+        style={styles.center}
+        text={`After pressing "Request Password Reset", you will receive an email with a confirmation code to reset your password.`}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  justifyBetween: { justifyContent: "space-between", flex: 1 },
+  center: {
+    textAlign: "center",
+  },
+});

--- a/screens/Portal/Login.js
+++ b/screens/Portal/Login.js
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState, useGlobal } from "reactn";
-import { View, TouchableOpacity, Linking } from "react-native";
+import { View, TouchableOpacity, Linking, StyleSheet } from "react-native";
 
 import MeshStore from "../../utils/meshStore";
 import MeshAlert from "../../utils/meshAlert";
@@ -52,6 +52,10 @@ export default function Login() {
 
   const goToPolicy = () => {
     Linking.openURL("https://www.athar.es/policy");
+  };
+
+  const goToForgot = () => {
+    RootNavigation.navigate("portal", { screen: "forgot" });
   };
 
   const tryLogin = async () => {
@@ -112,7 +116,13 @@ export default function Login() {
       RootNavigation.navigate("app");
     } catch (err) {
       console.error(err);
-      if (err.message.indexOf("Invalid Credentials") !== -1) {
+      if (err.message.indexOf("The request is invalid") !== -1) {
+        MeshAlert({
+          title: "Error",
+          text: "Incorrect username or password",
+          icon: "error",
+        });
+      } else if (err.message.indexOf("Invalid Credentials") !== -1) {
         MeshAlert({
           title: "Error",
           text: "Invalid Credentials",
@@ -120,8 +130,6 @@ export default function Login() {
         });
       } else if (err.message.indexOf("Token expired") !== -1) {
         refreshToken();
-        // await MeshStore.clear();
-        // tryLogin();
       } else {
         MeshAlert({ title: "Error", text: err.message, icon: "error" });
       }
@@ -154,24 +162,44 @@ export default function Login() {
   }
 
   return (
-    <KeyboardAwareScrollView>
-      <View>
+    <View style={styles.justifyBetween}>
+      <KeyboardAwareScrollView>
         <Input onChangeText={updateEmail} value={email} label={"Email"} />
         <Input
           secureTextEntry
           onChangeText={updatePassword}
           value={password}
           label={"Password"}
-        />
-        <GlowButton text={"Login"} onPress={tryLogin} />
-      </View>
-      <TouchableOpacity onPress={goToPolicy}>
-        <DisclaimerText
-          text={
-            "By logging in you acknowledge that you agree to the Terms of Use and Privacy Policy."
+          nextSibling={
+            <TouchableOpacity onPress={goToForgot}>
+              <DisclaimerText blue text={"Forgot Password?"} />
+            </TouchableOpacity>
           }
         />
-      </TouchableOpacity>
-    </KeyboardAwareScrollView>
+        <GlowButton text={"Login"} onPress={tryLogin} />
+      </KeyboardAwareScrollView>
+      <DisclaimerText style={styles.center}>
+        By logging in you acknowledge that you agree to the{" "}
+        <TouchableOpacity onPress={goToPolicy}>
+          <DisclaimerText blue noMargin>
+            Terms of Use
+          </DisclaimerText>
+        </TouchableOpacity>{" "}
+        and{" "}
+        <TouchableOpacity onPress={goToPolicy}>
+          <DisclaimerText blue noMargin>
+            Privacy Policy
+          </DisclaimerText>
+        </TouchableOpacity>
+        .
+      </DisclaimerText>
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  justifyBetween: { justifyContent: "space-between", flex: 1 },
+  center: {
+    textAlign: "center",
+  },
+});

--- a/screens/Portal/Register.js
+++ b/screens/Portal/Register.js
@@ -1,6 +1,12 @@
 import React, { useState, useGlobal, useRef, useEffect } from "reactn";
 
-import { TouchableOpacity, Linking, View, Text } from "react-native";
+import {
+  TouchableOpacity,
+  Linking,
+  View,
+  Text,
+  StyleSheet,
+} from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 
 import MeshStore from "../../utils/meshStore";
@@ -51,6 +57,10 @@ export default function Register() {
     Linking.openURL("https://www.athares.us/policy");
   };
 
+  const goToForgot = () => {
+    RootNavigation.navigate("portal", { screen: "forgot" });
+  };
+
   const tryRegister = async () => {
     setLoading(true);
 
@@ -72,16 +82,16 @@ export default function Register() {
     }
 
     // Auth0's arbitrary stupid auth requirements
-    if (/(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])/.test(password) === false) {
-      MeshAlert({
-        title: "Error",
-        text:
-          "Password must contain a capital letter, a lowercase letter, and a number.",
-        icon: "error",
-      });
-      setLoading(false);
-      return false;
-    }
+    // if (/(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])/.test(password) === false) {
+    //   MeshAlert({
+    //     title: "Error",
+    //     text:
+    //       "Password must contain a capital letter, a lowercase letter, and a number.",
+    //     icon: "error",
+    //   });
+    //   setLoading(false);
+    //   return false;
+    // }
 
     try {
       // // Encrypt the user's private key in the database with the password
@@ -168,8 +178,8 @@ export default function Register() {
   }
 
   return (
-    <KeyboardAwareScrollView>
-      <View>
+    <View style={styles.justifyBetween}>
+      <KeyboardAwareScrollView>
         <Input
           label="First Name"
           onChangeText={setFirstName}
@@ -182,18 +192,38 @@ export default function Register() {
           secureTextEntry
           onChangeText={setPassword}
           value={password}
+          nextSibling={
+            <TouchableOpacity onPress={goToForgot}>
+              <DisclaimerText blue text={"Forgot Password?"} />
+            </TouchableOpacity>
+          }
         />
         {error !== "" && <Text style={{ color: "#FF0000" }}>{error}</Text>}
 
         <GlowButton text={"Register"} onPress={tryRegister} />
-      </View>
-      <TouchableOpacity onPress={goToPolicy}>
-        <DisclaimerText
-          text={
-            "By registering you acknowledge that you agree to the Terms of Use and Privacy Policy."
-          }
-        />
-      </TouchableOpacity>
-    </KeyboardAwareScrollView>
+      </KeyboardAwareScrollView>
+      <DisclaimerText style={styles.center}>
+        By registering you acknowledge that you agree to the{" "}
+        <TouchableOpacity onPress={goToPolicy}>
+          <DisclaimerText blue noMargin>
+            Terms of Use
+          </DisclaimerText>
+        </TouchableOpacity>{" "}
+        and{" "}
+        <TouchableOpacity onPress={goToPolicy}>
+          <DisclaimerText blue noMargin>
+            Privacy Policy
+          </DisclaimerText>
+        </TouchableOpacity>
+        .
+      </DisclaimerText>
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  justifyBetween: { justifyContent: "space-between", flex: 1 },
+  center: {
+    textAlign: "center",
+  },
+});

--- a/screens/Portal/Reset.js
+++ b/screens/Portal/Reset.js
@@ -1,0 +1,101 @@
+import React, { useRef, useEffect, useState } from "reactn";
+import { View, StyleSheet } from "react-native";
+
+import MeshAlert from "../../utils/meshAlert";
+
+import * as RootNavigation from "../../navigation/RootNavigation";
+import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
+
+import { UPDATE_PASSWORD } from "../../graphql/mutations";
+
+import Input from "../../components/Input";
+import GlowButton from "../../components/GlowButton";
+import DisclaimerText from "../../components/DisclaimerText";
+import CenteredLoaderWithText from "../../components/CenteredLoaderWithText";
+import { useMutation } from "@apollo/client";
+import { validatePassword } from "../../utils/validators";
+
+export default function ResetConfirm(props) {
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const [resetPassword] = useMutation(UPDATE_PASSWORD);
+
+  let _isMounted = useRef(false);
+
+  useEffect(() => {
+    _isMounted.current = true;
+
+    return () => {
+      _isMounted.current = false;
+    };
+  }, []);
+
+  const updatePassword = (text) => {
+    setPassword(text);
+  };
+
+  const sendRequest = async () => {
+    setLoading(true);
+    //  validate password length
+    const isValid = validatePassword({ password });
+
+    if (isValid !== undefined) {
+      MeshAlert({
+        title: "Error",
+        text: isValid[Object.keys(isValid)[0]][0],
+        icon: "error",
+      });
+      setLoading(false);
+      return false;
+    }
+
+    try {
+      await resetPassword({
+        variables: {
+          token: props.route.params.hashedCode,
+          password,
+        },
+      });
+
+      _isMounted.current && setLoading(false);
+
+      RootNavigation.navigate("portal", { screen: "login" });
+    } catch (err) {
+      MeshAlert({ title: "Error", text: err.message, icon: "error" });
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return <CenteredLoaderWithText text={"Updating Your Password"} />;
+  }
+
+  return (
+    <View style={styles.justifyBetween}>
+      <KeyboardAwareScrollView>
+        <DisclaimerText
+          text={`Please enter a new password to use with the email address that received this reset request.`}
+        />
+        <Input
+          secureTextEntry
+          onChangeText={updatePassword}
+          value={password}
+          label={"New Password"}
+        />
+        <GlowButton text={"Update Password"} onPress={sendRequest} />
+      </KeyboardAwareScrollView>
+      <DisclaimerText
+        style={styles.center}
+        text={`By pressing "Update Password", your password will be updated and you will be redirected to the login page. You may then use your new password to log in.`}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  justifyBetween: { justifyContent: "space-between", flex: 1 },
+  center: {
+    textAlign: "center",
+  },
+});

--- a/screens/Portal/ResetConfirm.js
+++ b/screens/Portal/ResetConfirm.js
@@ -1,0 +1,93 @@
+import React, { useRef, useEffect, useState } from "reactn";
+import { View, StyleSheet } from "react-native";
+
+import MeshAlert from "../../utils/meshAlert";
+
+import * as RootNavigation from "../../navigation/RootNavigation";
+import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
+
+import { GET_RESET_REQUEST } from "../../graphql/queries";
+import { sha } from "../../utils/crypto";
+
+import Input from "../../components/Input";
+import GlowButton from "../../components/GlowButton";
+import DisclaimerText from "../../components/DisclaimerText";
+import CenteredLoaderWithText from "../../components/CenteredLoaderWithText";
+import useImperativeQuery from "../../utils/useImperativeQuery";
+
+export default function ResetConfirm() {
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const checkResetRequest = useImperativeQuery(GET_RESET_REQUEST);
+
+  let _isMounted = useRef(false);
+
+  useEffect(() => {
+    _isMounted.current = true;
+
+    return () => {
+      _isMounted.current = false;
+    };
+  }, []);
+
+  const updateCode = (text) => {
+    setCode(text.toUpperCase());
+  };
+
+  const sendRequest = async () => {
+    setLoading(true);
+    if (code.length !== 6) {
+      MeshAlert({
+        title: "Error",
+        text: "Not a valid code",
+        icon: "error",
+      });
+      setLoading(false);
+      return false;
+    }
+    try {
+      let hashedCode = sha(code.toUpperCase());
+
+      await checkResetRequest({
+        token: hashedCode,
+      });
+
+      _isMounted.current && setLoading(false);
+
+      RootNavigation.navigate("reset", {
+        hashedCode: sha(code),
+      });
+    } catch (err) {
+      MeshAlert({ title: "Error", text: err.message, icon: "error" });
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return <CenteredLoaderWithText text={"Verifying Reset Request..."} />;
+  }
+
+  return (
+    <View style={styles.justifyBetween}>
+      <KeyboardAwareScrollView>
+        <DisclaimerText
+          text={`You should have received an email with a code to reset your request; please enter it now.`}
+        />
+        <Input onChangeText={updateCode} value={code} label={"Reset Code"} />
+        <GlowButton text={"Verify Code"} onPress={sendRequest} />
+      </KeyboardAwareScrollView>
+      <DisclaimerText
+        style={styles.center}
+        text={`After pressing "Verify Code", we'll make sure that code is valid and let you reset your password.`}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  justifyBetween: { justifyContent: "space-between", flex: 1 },
+  center: {
+    textAlign: "center",
+  },
+});

--- a/screens/Portal/index.js
+++ b/screens/Portal/index.js
@@ -6,6 +6,10 @@ import { createStackNavigator } from "@react-navigation/stack";
 
 import Login from "./Login";
 import Register from "./Register";
+import Reset from "./Reset";
+import ResetConfirm from "./ResetConfirm";
+
+import Forgot from "./Forgot";
 
 const Stack = createStackNavigator();
 
@@ -14,7 +18,9 @@ export default function Portal(props) {
   const [, setActiveCircle] = useGlobal("activeCircle");
   const [, setActiveRevision] = useGlobal("activeRevision");
 
-  const [screen, setScreen] = useState("login");
+  const [screen, setScreen] = useState(
+    props.route?.state?.routes[0]?.name || "login"
+  );
 
   useEffect(() => {
     setActiveChannel(null);
@@ -23,11 +29,13 @@ export default function Portal(props) {
   }, []);
 
   useEffect(() => {
-    props.navigation.navigate("portal", { screen });
-  }, [screen]);
+    setScreen(
+      props.route.params?.screen || props.route?.state?.routes[0]?.name
+    );
+  }, [props.route]);
 
   const onUpdateTab = (tab) => {
-    setScreen(tab);
+    props.navigation.navigate("portal", { screen: tab });
   };
 
   return (
@@ -36,6 +44,7 @@ export default function Portal(props) {
         style={{ height: 30, width: 180, marginTop: 60, marginBottom: 25 }}
         source={require("../../assets/images/Athares-type-small-white.png")}
       />
+
       <TitleTabs
         activeTab={screen}
         tabs={["login", "register"]}
@@ -56,6 +65,21 @@ export default function Portal(props) {
         <Stack.Screen
           name="login"
           component={Login}
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen
+          name="forgot"
+          component={Forgot}
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen
+          name="resetConfirm"
+          component={ResetConfirm}
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen
+          name="reset"
+          component={Reset}
           options={{ headerShown: false }}
         />
       </Stack.Navigator>

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -109,3 +109,18 @@ export const validateEmailAddress = ({ email }) => {
     }
   );
 };
+
+export const validatePassword = ({ password }) => {
+  return validate(
+    { password },
+    {
+      password: {
+        presence: { allowEmpty: false },
+        length: {
+          minimum: 6,
+          tooShort: "must be at least 8 characters.",
+        },
+      },
+    }
+  );
+};


### PR DESCRIPTION
I don't know that this closes any issues, because I am allergic to closing my own issues, and instead create additional work for myself that I can't check off.

Anyway I've updated the Auth Profile in 8base to use Auth0 instead of their home-grown solution (which required no auth changes on the client besides updating the auth profile ID) and now we can roll our own reset and forgot functions using resolvers and Auth0's API (see  (relevant PR for functions)[https://github.com/atharesinc/functions/pull/1] )