### PR TITLE
added privacy, splash, about, and 404 screens

### DIFF
--- a/App.js
+++ b/App.js
@@ -63,16 +63,11 @@ export default function App(props) {
   const [isMobile, setIsMobile] = useGlobal("isMobile");
   const [, setSearchedCircles] = useGlobal("searchedCircles");
 
-  // const { getInitialState } = useLinking(navigationRef);
-
   // Load any resources or data that we need prior to rendering the app
   useEffect(() => {
     async function loadResourcesAndDataAsync() {
       try {
         SplashScreen.preventAutoHideAsync();
-
-        // Load our initial navigation state
-        // setInitialNavigationState(await getInitialState());
 
         // Load fonts
         await Font.loadAsync({
@@ -133,7 +128,6 @@ export default function App(props) {
   }, [dimensions]);
 
   const shouldRenderSideBar = isMobile ? null : <Channels renderAsSidebar />;
-  // isMenuOpen ? { overflow: "hidden" } : {};
 
   if (!isLoadingComplete && !props.skipLoadingScreen) {
     return null;

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,6 +1,6 @@
 import React, { useGlobal } from "reactn";
 
-import { Text, TouchableOpacity, StyleSheet, View } from "react-native";
+import { Text, TouchableOpacity, StyleSheet, View, Image } from "react-native";
 import * as RootNavigation from "../navigation/RootNavigation";
 import { Feather } from "@expo/vector-icons";
 import {
@@ -11,6 +11,7 @@ import {
 import { useQuery } from "@apollo/client";
 import RevisionCategory from "./RevisionCategory";
 import WithBadge from "./WithBadge";
+import LinkButton from "./LinkButton";
 
 import AsyncImage from "./AsyncImage";
 
@@ -18,11 +19,11 @@ function Header({
   // loggedIn = false,
   // belongsToCircle = false,
   scene,
-  ...props
+  // ...props
 }) {
   const [showSearch, setShowSearch] = useGlobal("showSearch");
   const [dmSettings, setDMSettings] = useGlobal("dmSettings");
-  // const [user] = useGlobal("user");
+  const [user] = useGlobal("user");
   const [activeChannel] = useGlobal("activeChannel");
   const [activeRevision] = useGlobal("activeRevision");
   const [activeViewUser] = useGlobal("activeViewUser");
@@ -41,11 +42,20 @@ function Header({
     setShowSearch(!showSearch);
   };
 
+  const goToLogin = () => {
+    RootNavigation.navigate("portal", { screen: "login" });
+  };
+
+  const goToApp = () => {
+    RootNavigation.navigate("app");
+  };
+
   const back = () => {
-    if (!props.previous) {
-      RootNavigation.navigate("app");
-    }
-    props.navigation.goBack(null);
+    // if (!props.previous) {
+    RootNavigation.navigate("app");
+    //   return;
+    // }
+    // props.navigation.goBack(null);
   };
 
   const more = () => {
@@ -243,6 +253,34 @@ function Header({
     );
   }
 
+  if (["splash", "privacy", "about"].indexOf(name) !== -1) {
+    return (
+      <View style={styles.transparentHeader}>
+        {/* <Image
+          source={require("../assets/images/Athares-owl-logo-large-white.png")}
+          style={styles.userIcon}
+        /> */}
+        <Image
+          source={require("../assets/images/Athares-type-large-white.png")}
+          style={styles.logoType}
+        />
+        {user ? (
+          <LinkButton onPress={goToApp} text={"App"} style={{ margin: 0 }} />
+        ) : (
+          <LinkButton
+            onPress={goToLogin}
+            text={"Login"}
+            style={{ margin: 0 }}
+          />
+        )}
+      </View>
+    );
+  }
+
+  if (name === "notFound") {
+    return null;
+  }
+
   // render dashboard with user drawer
 
   let img = require("../assets/images/user-default.png");
@@ -250,7 +288,6 @@ function Header({
   if (data && data.user) {
     img = { uri: data.user.icon };
   }
-
   return (
     <View style={styles.header}>
       <TouchableOpacity onPress={toggleDrawer}>
@@ -288,8 +325,6 @@ function Header({
       )}
     </View>
   );
-  // }
-  // return <View style={styles.header} />;
 }
 
 const styles = StyleSheet.create({
@@ -325,6 +360,10 @@ const styles = StyleSheet.create({
     height: 35,
     width: 35,
   },
+  logoType: {
+    height: 20,
+    width: 125,
+  },
   userIconWrapper: {
     borderRadius: 9999,
     borderColor: "#FFFFFF",
@@ -334,6 +373,16 @@ const styles = StyleSheet.create({
     overflow: "hidden",
     alignItems: "center",
     justifyContent: "center",
+  },
+  transparentHeader: {
+    backgroundColor: "transparent",
+    height: 60,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 15,
+    width: "100%",
+    zIndex: 0,
   },
 });
 

--- a/components/LinkButton.js
+++ b/components/LinkButton.js
@@ -1,39 +1,21 @@
 import React, { useGlobal, useState } from "reactn";
-import {
-  TouchableOpacity,
-  View,
-  Text,
-  StyleSheet,
-  Platform,
-} from "react-native";
+import { TouchableOpacity, Text, StyleSheet, Platform } from "react-native";
 
-export default function GhostButton({
+export default function LinkButton({
   style = {},
   textStyle = {},
   text = "",
   wide = false,
-  lowercase = false,
-  blue = false,
   ...props
 }) {
   const [activeTheme] = useGlobal("activeTheme");
   const wrapperStyle = [styles.wrapper, wide ? { width: "100%" } : {}, style];
   const [isFocused, setIsFocused] = useState(false);
 
-  const buttonStyles = [
-    styles.wrapperInner,
-    wide ? { width: "100%" } : {},
-    blue
-      ? { borderColor: activeTheme.COLORS.BLUE1, backgroundColor: "#282a38aa" }
-      : {},
-    isFocused ? { backgroundColor: "#FFFFFF" } : {},
-  ];
-
   const finalTextStyle = [
     styles.text,
     textStyle,
-    blue ? { color: activeTheme.COLORS.BLUE1 } : {},
-    isFocused ? { color: activeTheme.COLORS.DARK } : {},
+    isFocused ? { color: activeTheme.COLORS.BLUE1 } : {},
   ];
 
   const focusUp = () => {
@@ -43,7 +25,6 @@ export default function GhostButton({
     setIsFocused(false);
   };
 
-  const finalText = lowercase ? text : text.toUpperCase();
   return (
     <TouchableOpacity
       style={wrapperStyle}
@@ -51,9 +32,7 @@ export default function GhostButton({
       onFocus={focusUp}
       onBlur={focusOff}
     >
-      <View style={buttonStyles}>
-        <Text style={finalTextStyle}>{finalText}</Text>
-      </View>
+      <Text style={finalTextStyle}>{text.toUpperCase()}</Text>
     </TouchableOpacity>
   );
 }
@@ -68,15 +47,6 @@ const styles = StyleSheet.create({
         outlineStyle: "none",
       },
     }),
-  },
-  wrapperInner: {
-    borderRadius: 9999,
-    backgroundColor: "transparent",
-    justifyContent: "center",
-    alignItems: "center",
-    borderColor: "#FFFFFF",
-    borderWidth: 3,
-    paddingHorizontal: 15,
   },
   text: {
     fontSize: 15,

--- a/components/Menu.js
+++ b/components/Menu.js
@@ -1,7 +1,6 @@
 import React, { useGlobal } from "reactn";
 import * as RootNavigation from "../navigation/RootNavigation";
 import { ScrollView, StyleSheet, View } from "react-native";
-import { Linking } from "expo";
 import { useQuery, useApolloClient } from "@apollo/client";
 import UserLink from "./UserLink";
 import NoUserLink from "./NoUserLink";
@@ -69,11 +68,11 @@ function SideMenu() {
   };
 
   const goToAbout = () => {
-    Linking.openURL("https://www.athar.es/about");
+    RootNavigation.navigate("about");
   };
 
   const goToPolicy = () => {
-    Linking.openURL("https://www.athar.es/policy");
+    RootNavigation.navigate("privacy");
   };
 
   const { data } = useQuery(GET_USER_BY_ID, {

--- a/navigation/useLinking.js
+++ b/navigation/useLinking.js
@@ -1,12 +1,13 @@
-// import { useLinking } from "@react-navigation/native";
-// import { Linking } from "expo";
-
 export const linkingConfig = {
   prefixes: ["https://athar.es", "athares://", "http://localhost:19006"],
   config: {
     screens: {
+      splash: "",
+      about: "about",
+      roadmap: "roadmap",
+      privacy: "privacy",
       // GOOD
-      app: "",
+      app: "/app",
       // GOOD
       portal: {
         screens: {
@@ -45,6 +46,7 @@ export const linkingConfig = {
       viewUser: "profile",
       // GOOD
       viewOtherUser: "user/:user",
+      notFound: "*",
     },
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9155,9 +9155,9 @@
       "integrity": "sha512-B7vi0mzWXleKeI2iiFrCC6RiIYxtoK7RWp/Wmaxjlux4Yi6SBDjIoL0tXvfa14C7ZiJjA4wm1/3lcbhiGvQOTg=="
     },
     "expo-linking": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-1.0.4.tgz",
-      "integrity": "sha512-tKZvn3D2t/rJQQbDXZaPl3pEZvyO2coSO1WHtXeOCUaWFjrrHxjW0HAZ2H2iR0zALPq/lXo0Po83RsES3E0DAg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-1.0.5.tgz",
+      "integrity": "sha512-LH26/ilFU0rCdsO1SJbNqoii3jTBqHdEfSloXhEb73aKdQT2BG6z5IjFIQXV2RiCmxNJbotdbfXyWSPqPoCEwg==",
       "requires": {
         "expo-constants": "~9.2.0",
         "qs": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "expo-image-manipulator": "~8.3.0",
     "expo-image-picker": "~9.1.0",
     "expo-linear-gradient": "~8.3.0",
+    "expo-linking": "^1.0.5",
     "expo-network": "~2.3.0",
     "expo-permissions": "~9.3.0",
     "expo-secure-store": "~9.2.0",

--- a/screens/About/index.js
+++ b/screens/About/index.js
@@ -1,0 +1,120 @@
+import React from "react";
+
+import DisclaimerText from "../../components/DisclaimerText";
+import Title from "../../components/Title";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+
+export default function About() {
+  return (
+    <ScrollView contentContainerStyle={[styles.wrapper]}>
+      <View style={styles.hero}>
+        <DisclaimerText grey spaced>
+          What is Athares?
+        </DisclaimerText>
+
+        <Text style={styles.bigText}>
+          The most ambitious startup in history, maybe.
+        </Text>
+
+        <DisclaimerText grey upper spaced style={{ fontSize: 15 }}>
+          EVERYTHING YOU NEED TO KNOW ABOUT ATHARES
+        </DisclaimerText>
+      </View>
+      <View style={styles.QAWrapper}>
+        {questions.map((q) => (
+          <View key={q.id} style={styles.block}>
+            <Title text={q.question} />
+            <DisclaimerText text={q.text} />
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    alignItems: "stretch",
+    justifyContent: "flex-start",
+    width: "100%",
+    flex: 1,
+  },
+  hero: {
+    padding: 15,
+  },
+  QAWrapper: {
+    width: "100%",
+    // flex: 1,
+    backgroundColor: "#282a38",
+    padding: 15,
+  },
+  bigText: {
+    fontSize: 40,
+    color: "#FFFFFF",
+    fontFamily: "SpaceGrotesk",
+    marginBottom: 30,
+  },
+  innerWrapper: {
+    alignItems: "stretch",
+    justifyContent: "center",
+    width: "100%",
+    padding: 15,
+    flex: 1,
+  },
+  buttonRow: {
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    alignItems: "center",
+  },
+  block: {
+    marginBottom: 10,
+  },
+});
+
+const questions = [
+  {
+    id: "what",
+    question: "In simple terms, what is Athares?",
+    text: `Athares is an app that allows people to create and manage their own governments, called Circles. Whether it's a high school club or a burgeoning democracy, Athares Distributed Democracy Platform acts as a security-first foundation for involvement, outreach, and policy. Vote on issues that are important to you!`,
+  },
+  {
+    id: "how-to-get-started",
+    question: "How can I use Athares today?",
+    text:
+      "Are you a member of a club or organization? Try creating a new Circle and invite some peers. See what you can come up with when you work together!",
+  },
+  {
+    id: "goals",
+
+    question: "What is the goal of Athares?",
+    text:
+      "The origin of Athares lies in the nearing-prospect of a colony on Mars.  A new colony will need to govern itself, and would eventually fall into the same political pitfalls as modern, terrestrial governments. We want to get it right the first time. Our goal is to avoid the mistakes we've seen in hundreds of years on Earth.  We want to create socially equitable and responsible government to ensure the survival and success of humans on other planets. Our ultimate goal is to empower individuals (regardless of home-planet) to actively participate in their society, to culitvate a political awareness, and to liberate passive citizens from inadequate status-quo of many governments. Be the change you want to see in this world.",
+  },
+  {
+    id: "have-blockchain",
+    question: "Does Athares run on a blockchain?",
+    text:
+      "Athares does not run on a blockchain and it probably won't.  Athares utilizes a client-first approach and Circles rely on active participation to drive functionality, however, we can't yet bridge the gap for creating a fully distributed system, end-to-end. Many of the technologies we'd like to use simply don't exist in the average device. Blockchain-based applications are too slow for most realtime interaction and don't scale well.  Athares uses it's own distributed ledger-like technology for 99% of users and in the meantime we're committed to building distributed systems that can survive the void of space.",
+  },
+  {
+    id: "why-distributed",
+
+    question: "Distributed Democracy? What?",
+    text:
+      "Inspired by the Direct Democracies around the world, Athares lets users vote on individual issues in their government. Removing representatives eliminates corruption, cuts government costs, and creates overnight progress.  In other models, people vote for the representatives, but little prevents these representatives from betraying their voters or from doing nothing.",
+  },
+  {
+    id: "why-not-direct",
+
+    question: "Shouldn't it be a Direct Democracy?",
+    text: `A resilient democracy needs to operate in a completely distributed fashion, so that no single person can control the system, and it has no single point of failure. A direct democracy is the perfect use for a distributed technology and infrastructure, thus the name "Distributed Democracy": a direct democracy managed in a distributed system.`,
+  },
+
+  {
+    id: "i-dont-understand-this",
+
+    question: "I don't understand any of this",
+    text:
+      "Athares just wants to make it easy to build groups where no one has to be the boss.",
+  },
+];

--- a/screens/NotFound/index.js
+++ b/screens/NotFound/index.js
@@ -1,0 +1,106 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import DisclaimerText from "../../components/DisclaimerText";
+import LinkButton from "../../components/LinkButton";
+import * as RootNavigation from "../../navigation/RootNavigation";
+
+export default function NotFound() {
+  const links = [
+    {
+      text: "Login",
+      route: "login",
+    },
+    {
+      text: "Home",
+      route: "app",
+    },
+    {
+      text: "About",
+      route: "about",
+    },
+    {
+      text: "Privacy",
+      route: "privacy",
+    },
+  ];
+
+  const nav = (route) => {
+    if (route === "login") {
+      RootNavigation.navigate("portal", { screen: "login" });
+      return;
+    }
+    RootNavigation.navigate(route);
+  };
+
+  return (
+    <View style={styles.wrapper}>
+      <View>
+        <View style={styles.centeredWrapper}>
+          {/* <View style={styles.borderRight}> */}
+          <Text style={styles.bold}>404</Text>
+          {/* </View> */}
+          <DisclaimerText grey style={styles.disclaimerOverride} noMargin>
+            This resource could not be found.
+          </DisclaimerText>
+        </View>
+        {/* list of links */}
+        <View style={styles.styleRow}>
+          {links.map((link) => (
+            <LinkButton
+              text={link.text}
+              key={link.route}
+              onPress={() => nav(link.route)}
+              style={styles.marginHorizontal}
+              textStyle={styles.kerning}
+            />
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
+    flex: 1,
+    padding: 5,
+  },
+  bold: {
+    fontWeight: "bold",
+    color: "#FFFFFF",
+    fontSize: 50,
+    marginBottom: 10,
+  },
+  styleRow: {
+    marginTop: 10,
+    flexDirection: "row",
+    justifyContent: "space-around",
+    flexWrap: "wrap",
+    flex: 1,
+  },
+  centeredWrapper: {
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    flex: 1,
+    marginBottom: 10,
+  },
+  borderRight: {
+    borderRightWidth: 1,
+    borderRightColor: "#FFFFFFb7",
+    marginRight: 10,
+    paddingRight: 10,
+  },
+  disclaimerOverride: {
+    fontSize: 15,
+  },
+  marginHorizontal: {
+    marginHorizontal: 20,
+  },
+  kerning: {
+    letterSpacing: 2,
+  },
+});

--- a/screens/Portal/Login.js
+++ b/screens/Portal/Login.js
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState, useGlobal } from "reactn";
-import { View, TouchableOpacity, Linking, StyleSheet } from "react-native";
+import { View, TouchableOpacity, StyleSheet } from "react-native";
 
 import MeshStore from "../../utils/meshStore";
 import MeshAlert from "../../utils/meshAlert";
@@ -51,7 +51,7 @@ export default function Login() {
   };
 
   const goToPolicy = () => {
-    Linking.openURL("https://www.athar.es/policy");
+    RootNavigation.navigate("privacy");
   };
 
   const goToForgot = () => {

--- a/screens/Portal/Register.js
+++ b/screens/Portal/Register.js
@@ -1,12 +1,6 @@
 import React, { useState, useGlobal, useRef, useEffect } from "reactn";
 
-import {
-  TouchableOpacity,
-  Linking,
-  View,
-  Text,
-  StyleSheet,
-} from "react-native";
+import { TouchableOpacity, View, Text, StyleSheet } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 
 import MeshStore from "../../utils/meshStore";
@@ -54,7 +48,7 @@ export default function Register() {
   };
 
   const goToPolicy = () => {
-    Linking.openURL("https://www.athares.us/policy");
+    RootNavigation.navigate("privacy");
   };
 
   const goToForgot = () => {

--- a/screens/Privacy/index.js
+++ b/screens/Privacy/index.js
@@ -1,0 +1,134 @@
+import React from "react";
+import { View, StyleSheet, TouchableOpacity, Platform } from "react-native";
+import Title from "../../components/Title";
+import LinkButton from "../../components/LinkButton";
+import * as RootNavigation from "../../navigation/RootNavigation";
+// import * as Linking from "expo-linking";
+import * as WebBrowser from "expo-web-browser";
+
+export default function NotFound() {
+  const links = [
+    {
+      text: "Login",
+      route: "login",
+    },
+    {
+      text: "Home",
+      route: "app",
+    },
+    {
+      text: "About",
+      route: "about",
+    },
+    {
+      text: "Privacy",
+      route: "privacy",
+    },
+  ];
+
+  const nav = (route) => {
+    if (route === "login") {
+      RootNavigation.navigate("portal", { screen: "login" });
+      return;
+    }
+    RootNavigation.navigate(route);
+  };
+
+  const goToPolicy = () => {
+    const link = `https://app.termly.io/document/privacy-policy/a5978d1c-8a56-4910-b0b5-32b1ff526936`;
+    if (Platform.OS === "web") {
+      window.open(link, "_blank");
+      return;
+    }
+    WebBrowser.openBrowserAsync(link);
+  };
+  const goToGitHub = () => {
+    const link = "https://github.com/atharesinc";
+
+    if (Platform.OS === "web") {
+      window.open(link, "_blank");
+      return;
+    }
+    WebBrowser.openBrowserAsync(link);
+  };
+
+  return (
+    <View style={styles.wrapper}>
+      <View>
+        <View style={styles.centeredWrapper}>
+          <TouchableOpacity onPress={goToPolicy}>
+            <Title
+              grey
+              style={styles.disclaimerOverride}
+              text={"Privacy Policy"}
+            />
+          </TouchableOpacity>
+          <TouchableOpacity onPress={goToGitHub}>
+            <Title
+              grey
+              style={styles.disclaimerOverride}
+              text={"Athares Open Source"}
+            />
+          </TouchableOpacity>
+        </View>
+        {/* list of links */}
+        <View style={styles.styleRow}>
+          {links.map((link) => (
+            <LinkButton
+              text={link.text}
+              key={link.route}
+              onPress={() => nav(link.route)}
+              style={styles.marginHorizontal}
+              textStyle={styles.kerning}
+            />
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
+    flex: 1,
+    padding: 5,
+  },
+  bold: {
+    fontWeight: "bold",
+    color: "#FFFFFF",
+    fontSize: 50,
+    marginBottom: 10,
+  },
+  styleRow: {
+    marginTop: 10,
+    flexDirection: "row",
+    justifyContent: "space-around",
+    flexWrap: "wrap",
+    flex: 1,
+  },
+  centeredWrapper: {
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    flex: 1,
+    marginBottom: 10,
+  },
+  borderRight: {
+    borderRightWidth: 1,
+    borderRightColor: "#FFFFFFb7",
+    marginRight: 10,
+    paddingRight: 10,
+  },
+  disclaimerOverride: {
+    fontSize: 15,
+  },
+  marginHorizontal: {
+    marginHorizontal: 20,
+  },
+  kerning: {
+    letterSpacing: 2,
+  },
+});

--- a/screens/Roadmap/index.js
+++ b/screens/Roadmap/index.js
@@ -1,0 +1,60 @@
+import React from "react";
+
+import DisclaimerText from "../../components/DisclaimerText";
+
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import GhostButton from "../../components/GhostButton";
+import GlowButton from "../../components/GlowButton";
+
+export default function ViewOtherUser() {
+  // const [isMobile] = useGlobal("isMobile");
+
+  return (
+    <ScrollView contentContainerStyle={[styles.wrapper]}>
+      <View style={styles.innerWrapper}>
+        <Text style={styles.bigText}>Good Government is Democratic.</Text>
+        <DisclaimerText blue>
+          Athares helps you build good democracies. Participate in organizations
+          directly, secured with distributed technology.
+        </DisclaimerText>
+        <View style={styles.buttonRow}>
+          <GhostButton text={"Learn More"} />
+          <DisclaimerText grey>or</DisclaimerText>
+          <GlowButton text={"Get Started"} />
+        </View>
+      </View>
+      <View style={styles.footer}>
+        <DisclaimerText grey>Footer</DisclaimerText>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    alignItems: "stretch",
+    justifyContent: "flex-start",
+    width: "100%",
+    flex: 1,
+  },
+  innerWrapper: {
+    alignItems: "stretch",
+    justifyContent: "flex-start",
+    width: "100%",
+    padding: 5,
+  },
+  header: {
+    fontSize: 13,
+    color: "#FFFFFF",
+    marginBottom: 25,
+    fontWeight: "bold",
+  },
+  buttonRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  footer: {
+    height: 60,
+    backgroundColor: "#FFFFFF",
+  },
+});

--- a/screens/Splash/index.js
+++ b/screens/Splash/index.js
@@ -1,0 +1,72 @@
+import React from "react";
+
+import DisclaimerText from "../../components/DisclaimerText";
+
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import GhostButton from "../../components/GhostButton";
+import * as RootNavigation from "../../navigation/RootNavigation";
+
+export default function Splash() {
+  const goToAbout = () => {
+    RootNavigation.navigate("about");
+  };
+  const goToLogin = () => {
+    RootNavigation.navigate("portal", { screen: "login" });
+  };
+  return (
+    <ScrollView contentContainerStyle={[styles.wrapper]}>
+      <View style={styles.innerWrapper}>
+        <Text style={styles.bigText}>Good Government is Democratic.</Text>
+        <DisclaimerText blue style={{ fontSize: 15 }}>
+          Athares helps you build better groups. Participate in organizations
+          directly, secured with distributed technology.
+        </DisclaimerText>
+        <View style={styles.buttonRow}>
+          <GhostButton
+            text={"Learn More"}
+            lowercase
+            blue
+            style={{ marginRight: 10, marginBottom: 0 }}
+            onPress={goToAbout}
+          />
+          <DisclaimerText grey noMargin>
+            or
+          </DisclaimerText>
+          <GhostButton
+            text={"Get Started"}
+            lowercase
+            style={{ marginLeft: 10, marginBottom: 0 }}
+            onPress={goToLogin}
+          />
+        </View>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    alignItems: "stretch",
+    justifyContent: "flex-start",
+    width: "100%",
+    flex: 1,
+  },
+  bigText: {
+    fontSize: 40,
+    color: "#FFFFFF",
+    fontFamily: "SpaceGrotesk",
+    marginBottom: 30,
+  },
+  innerWrapper: {
+    alignItems: "stretch",
+    justifyContent: "center",
+    width: "100%",
+    padding: 15,
+    flex: 1,
+  },
+  buttonRow: {
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    alignItems: "center",
+  },
+});

--- a/screens/index.js
+++ b/screens/index.js
@@ -1,5 +1,5 @@
 import React, { useGlobal } from "reactn";
-
+import { Platform } from "react-native";
 import { createStackNavigator } from "@react-navigation/stack";
 
 import Channels from "./Channels";
@@ -18,6 +18,12 @@ import AddUser from "./AddUser";
 import ViewInvites from "./ViewInvites";
 import ViewUser from "./Me";
 import ViewOtherUser from "./ViewOtherUser";
+
+import Splash from "./Splash";
+import About from "./About";
+// import Roadmap from "./Roadmap";
+import Privacy from "./Privacy";
+import NotFound from "./NotFound";
 
 import Header from "../components/Header";
 import { pushTransition } from "../navigation/transitionConfigs";
@@ -41,6 +47,14 @@ export default function RootStack() {
       }}
     >
       {/* This is where all the screens go */}
+      {Platform.OS === "web" && (
+        <>
+          <Stack.Screen name="splash" component={Splash} />
+          <Stack.Screen name="about" component={About} />
+          {/* <Stack.Screen name="roadmap" component={Roadmap} /> */}
+          <Stack.Screen name="privacy" component={Privacy} />
+        </>
+      )}
       <Stack.Screen
         name="app"
         component={shouldDisplayNewsAsApp}
@@ -51,6 +65,7 @@ export default function RootStack() {
         component={Portal}
         // options={{ headerShown: false }}
       />
+
       <Stack.Screen name="createRevision" component={CreateRevision} />
       <Stack.Screen name="viewRevision" component={ViewRevision} />
 
@@ -67,6 +82,7 @@ export default function RootStack() {
       <Stack.Screen name="viewInvites" component={ViewInvites} />
       <Stack.Screen name="viewUser" component={ViewUser} />
       <Stack.Screen name="viewOtherUser" component={ViewOtherUser} />
+      <Stack.Screen name="notFound" component={NotFound} />
     </Stack.Navigator>
   );
 }


### PR DESCRIPTION
In which I shoddily reproduce some clerical and informative screens from the existing website to be included in the web version of the app, as well as having a catch-all route (404) for all platforms.

Closes #8 